### PR TITLE
Moved POJO

### DIFF
--- a/src/main/java/org/wecancodeit/reviews/Hashtag.java
+++ b/src/main/java/org/wecancodeit/reviews/Hashtag.java
@@ -1,4 +1,4 @@
-package hashtagpojo;
+package org.wecancodeit.reviews;
 
 public class Hashtag {
 

--- a/src/main/java/org/wecancodeit/reviews/models/HashtagStorage.java
+++ b/src/main/java/org/wecancodeit/reviews/models/HashtagStorage.java
@@ -1,6 +1,6 @@
 package org.wecancodeit.reviews.models;
 
-import hashtagpojo.Hashtag;
+import org.wecancodeit.reviews.Hashtag;
 
 import java.util.Collection;
 


### PR DESCRIPTION
Moved Hashtag POJO from its own package to the base package where all other POJOs are. Deleted hashtagpojo package. HashtagStorage refactored imports

Signed-off-by: Colin Wakefield <59844720+ColinWake@users.noreply.github.com>